### PR TITLE
Add: Dark mode toggle

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "lucide-react": "^0.544.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -12404,6 +12405,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "lucide-react": "^0.544.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,6 +24,32 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+    <script>
+      (function() {
+        var savedTheme = localStorage.getItem('theme');
+        var initialTheme = savedTheme || 'dark';
+        var bgColor = initialTheme === 'light' ? '#fdf6e3' : '#282c34';
+        var textColor = initialTheme === 'light' ? '#000000' : '#ffffff';
+        
+        document.write(
+          '<style>' +
+          '.theme-loading html, .theme-loading body, .theme-loading #root {' +
+          'background-color: ' + bgColor + ';' +
+          'color: ' + textColor + ';' +
+          'margin: 0;' +
+          'padding: 0;' +
+          'transition: none !important;' + // Only disable transitions during load
+          '}' +
+          '</style>'
+        );
+        
+        document.documentElement.setAttribute('data-theme', initialTheme);
+      })();
+    </script>
+    <!--
+      Script above sets theme before any content renders to mitigate a flash
+      of white on page reload.
+    -->
     <title>React App</title>
   </head>
   <body>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -34,8 +34,8 @@
         document.write(
           '<style>' +
           '.theme-loading html, .theme-loading body, .theme-loading #root {' +
-          'background-color: ' + bgColor + ';' +
-          'color: ' + textColor + ';' +
+          'background-color: ' + bgColor + '!important;' +
+          'color: ' + textColor + '!important;' +
           'margin: 0;' +
           'padding: 0;' +
           'transition: none !important;' + // Only disable transitions during load
@@ -44,6 +44,7 @@
         );
         
         document.documentElement.setAttribute('data-theme', initialTheme);
+        document.documentElement.classList.add('theme-loading');
       })();
     </script>
     <!--

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -14,14 +14,14 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background-color: var(--background);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   font-size: calc(10px + 2vmin);
-  color: white;
+  color: var(--text-color);
 }
 
 .App-link {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,13 +1,8 @@
 import logo from './logo.svg';
 import './App.css';
-import { useEffect } from 'react';
 import ThemeToggle from './components/ThemeToggle';
 
 function App() {
-
-  useEffect(() => {
-    document.documentElement.classList.remove('theme-loading');
-  })
 
   return (
   <div className="App theme-transition">

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,24 +1,32 @@
 import logo from './logo.svg';
 import './App.css';
+import { useEffect } from 'react';
+import ThemeToggle from './components/ThemeToggle';
 
 function App() {
+
+  useEffect(() => {
+    document.documentElement.classList.remove('theme-loading');
+  })
+
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+  <div className="App theme-transition">
+    <header className="App-header">
+      <img src={logo} className="App-logo" alt="logo" />
+      <p>
+        Edit <code>src/App.js</code> and save to reload.
+      </p>
+      <a
+        className="App-link"
+        href="https://reactjs.org"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Learn React
+      </a>
+      <ThemeToggle />
+    </header>
+  </div>
   );
 }
 

--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen } from './test-utils';
 import App from './App';
 
 test('renders learn react link', () => {

--- a/client/src/components/ThemeProvider.js
+++ b/client/src/components/ThemeProvider.js
@@ -5,9 +5,9 @@ const ThemeContext = createContext();
 export const ThemeProvider = ({ children }) => {
   const [theme, setTheme] = useState(() => {
     if (typeof window !== 'undefined') {
-      return localStorage.getItem('theme') || 'light';
+      return localStorage.getItem('theme') || 'dark';
     }
-    return 'light';
+    return 'dark';
   });
 
   // Only manage localStorage

--- a/client/src/components/ThemeProvider.js
+++ b/client/src/components/ThemeProvider.js
@@ -1,0 +1,30 @@
+import { createContext, useContext, useState, useEffect } from 'react';
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') || 'light';
+    }
+    return 'light';
+  });
+
+  // Only manage localStorage
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => prev === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/client/src/components/ThemeToggle.js
+++ b/client/src/components/ThemeToggle.js
@@ -1,0 +1,14 @@
+import '../index.css';
+import { useTheme } from './ThemeProvider.js';
+import { Sun, Moon } from 'lucide-react';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button onClick={toggleTheme} className="toggleBtn">
+      {theme === 'light' ? <Moon size={24} className="moon" />
+      : <Sun size={24} className="sun" />}
+    </button>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,21 @@
+.theme-transition * {
+  transition: background-color 0.4s ease, color 0.4s ease;
+}
+
+[data-theme="light"] {
+  --background: #fdf6e3;
+  --text-color: #000;
+  --toggle-color: #282c34;
+  transition: all 1s ease;
+}
+
+[data-theme="dark"] {
+  --background: #282c34;
+  --text-color: #fff;
+  --toggle-color: #fdf6e3;
+  transition: all 1s ease;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -10,4 +28,19 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
+}
+
+.toggleBtn {
+  background-color: transparent;
+  border: none;
+}
+
+.toggleBtn:hover {
+  cursor: pointer;
+}
+
+.moon, .sun {
+  color: var(--toggle-color);
+  fill: var(--toggle-color);
+  transition: color 0.3s ease, fill 0.3s ease;
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { ThemeProvider } from './components/ThemeProvider';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/client/src/test-utils.js
+++ b/client/src/test-utils.js
@@ -1,0 +1,14 @@
+import { render as rtlRender, screen } from '@testing-library/react';
+import { ThemeProvider } from './components/ThemeProvider';
+
+function render(ui, options = {}) {
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <ThemeProvider>{children}</ThemeProvider>
+    ),
+    ...options,
+  });
+}
+
+export * from '@testing-library/react';
+export { render, screen };


### PR DESCRIPTION
## Description
Implements theme toggling capabilities for website

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes Made
- Created ThemeToggle and ThemeProvider
- Inserted ThemeToggle into existing header within App.js (ideally it will live within an actual header component)
- Wrapped app in ThemeProvider within index.js
- Inserted script in head of index.html to set text and background colors to fit theme saved in local storage (or default dark) to mitigate screen flashing when refreshing page.
- Created [data-theme] selectors in index.css that define background, text, and toggle icon color. Can also be used to set colors of future components of app to support transition.
- Used targeted * to force theme transition to happen while avoiding over-scoping.
- Added lucide icons to use for toggle button
- Created test_utils.js to allow for ThemeProvider to render properly within testing — passed both render and screen through so they are still accessible in App.test

## Testing
Describe how you tested these changes:
- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [x] Manual testing performed

## Screenshots (if applicable)
https://github.com/user-attachments/assets/004d11ea-d39f-4c56-b148-bf010a303de6

## Related Issues
Closes #18 